### PR TITLE
output file needs to be closed before being deleted

### DIFF
--- a/scripts/write_project_tcl_git.tcl
+++ b/scripts/write_project_tcl_git.tcl
@@ -732,6 +732,7 @@ proc wr_bd {} {
     # Making sure BD is not locked
     set is_locked [get_property IS_LOCKED [get_files [list "$bd_file"] ] ]
     if { $is_locked == 1 } {
+      close $a_global_vars(fh)
       file delete $a_global_vars(script_file)
       if { $a_global_vars(b_arg_quiet) } {
         reset_msg_setting


### PR DESCRIPTION
OS: Win 10
Vivado 2019.1

one of the BD file in my design needs to be upgraded (IS_LOCKED is true)
![image](https://user-images.githubusercontent.com/60413008/89930478-aa435f80-dbbf-11ea-86a1-2aad46deb9f1.png)

I get the following error when running _wproj_ and _git commit_: 
>error deleting "[path to project]/sensor_board.tcl": permission denied

This error message suppresses the more useful message set in the code, making it hard to figure the issue. The file is also not released as long as the vivado project stays open (can't delete it manually)

This pull request solves the issue. Resulting in the desired behavior (file delete) and error message
> ERROR: [Vivado-projutils-18] Project tcl cannot be written as the design contains one or more  locked/out-of-date design(s). Please run report_ip_status and update the design.
