### PR TITLE
I added two options, -no_layout and -exclude_external_ips

### DIFF
--- a/scripts/git_wrapper.tcl
+++ b/scripts/git_wrapper.tcl
@@ -53,7 +53,7 @@ namespace eval ::git_wrapper {
         set proj_file [current_project].tcl
 
         # Generate project and add it
-        write_project_tcl_git -no_copy_sources -force $proj_file
+        write_project_tcl_git -no_copy_sources -force -no_layout $proj_file
         puts $proj_file
         exec git add $proj_file
 
@@ -76,6 +76,6 @@ namespace eval ::git_wrapper {
         # Generate project
         set proj_file [current_project].tcl
         puts $proj_file
-        write_project_tcl_git -no_copy_sources -force $proj_file
+        write_project_tcl_git -no_copy_sources -force -no_layout $proj_file
     }
 }

--- a/scripts/write_project_tcl_git.tcl
+++ b/scripts/write_project_tcl_git.tcl
@@ -108,6 +108,7 @@ proc write_project_tcl_git {args} {
       "-use_bd_files"         { set a_global_vars(b_arg_use_bd_files) 1 }
       "-internal"             { set a_global_vars(b_internal) 1 }
       "-quiet"                { set a_global_vars(b_arg_quiet) 1}
+      "-exclude_external_ips" { set a_global_vars(exclude_external_ips) 1}
       default {
         # is incorrect switch specified?
         if { [regexp {^-} $option] } {
@@ -241,6 +242,7 @@ proc reset_global_vars {} {
   set a_global_vars(def_val_fh)           0
   set a_global_vars(script_file)          ""
   set a_global_vars(b_arg_quiet)          0
+  set a_global_vars(exclude_external_ips) 0
   
   if { [get_param project.enableMergedProjTcl] } {
     set a_global_vars(b_arg_use_bd_files)   0
@@ -599,9 +601,9 @@ proc write_bd_as_proc { bd_file } {
   } 
   set temp_bd_file [file join $temp_dir "temp_$temp_offset.tcl"]
   if { $a_global_vars(b_arg_no_ip_version) } {
-    write_bd_tcl -no_project_wrapper -no_ip_version -make_local -include_layout $temp_bd_file
-  } else {
-    write_bd_tcl -no_project_wrapper -make_local -include_layout $temp_bd_file
+      write_bd_tcl -no_project_wrapper -no_ip_version -make_local -include_layout $temp_bd_file
+    } else {
+      write_bd_tcl -no_project_wrapper -make_local -include_layout $temp_bd_file
   }
 
   # Set non default properties for the BD
@@ -843,7 +845,9 @@ proc write_specified_fileset { proj_dir proj_name filesets } {
             } else {
               set rel_file_path "[get_relative_file_path_for_source $path [get_script_execution_dir]]"
               # Filter out IP repositories outside of the project directory
-              if { [string first .. $rel_file_path] == 0 } { continue }
+              if { $a_global_vars(exclude_external_ips) } {
+                if { [string first .. $rel_file_path] == 0 } { continue }
+              }
               set path "\[file normalize \"\$origin_dir/$rel_file_path\"\]"
               lappend path_list $path
             }

--- a/scripts/write_project_tcl_git.tcl
+++ b/scripts/write_project_tcl_git.tcl
@@ -109,6 +109,7 @@ proc write_project_tcl_git {args} {
       "-internal"             { set a_global_vars(b_internal) 1 }
       "-quiet"                { set a_global_vars(b_arg_quiet) 1}
       "-exclude_external_ips" { set a_global_vars(exclude_external_ips) 1}
+      "-no_layout"            { set a_global_vars(b_no_layout) 1}
       default {
         # is incorrect switch specified?
         if { [regexp {^-} $option] } {
@@ -243,6 +244,7 @@ proc reset_global_vars {} {
   set a_global_vars(script_file)          ""
   set a_global_vars(b_arg_quiet)          0
   set a_global_vars(exclude_external_ips) 0
+  set a_global_vars(b_no_layout)          0
   
   if { [get_param project.enableMergedProjTcl] } {
     set a_global_vars(b_arg_use_bd_files)   0
@@ -601,9 +603,17 @@ proc write_bd_as_proc { bd_file } {
   } 
   set temp_bd_file [file join $temp_dir "temp_$temp_offset.tcl"]
   if { $a_global_vars(b_arg_no_ip_version) } {
+    if { $a_global_vars(b_no_layout) } {
+      write_bd_tcl -no_project_wrapper -no_ip_version -make_local $temp_bd_file
+    } else {
       write_bd_tcl -no_project_wrapper -no_ip_version -make_local -include_layout $temp_bd_file
+    }
+  } else {
+    if { $a_global_vars(b_no_layout) } {
+      write_bd_tcl -no_project_wrapper -make_local $temp_bd_file
     } else {
       write_bd_tcl -no_project_wrapper -make_local -include_layout $temp_bd_file
+    }  
   }
 
   # Set non default properties for the BD


### PR DESCRIPTION
Hello sir, thanks for your great repo, these are my changes and since im using vivado 2019.2 i had to add a new branch named v2019.2

-no_layout: This provides users with the option to include or exclude BD layout changes in their final TCL script. Since these changes don't affect the overall design behavior, I decided to use this feature in git_wrapper.tcl.

-exclude_external_ips: This is meant to filter out IP repositories outside of the project directory optionally in git_wrapper.tcl file, since each IP in my vivado project has its own example design project, and this example design which is located in vivado_project folder of the ip directory, has its own dependencies and may need other custom IPs to work properly, so they cant be located next to vivado_project because if located it seems that there are several IPs in the same directory, so i added this feature and now IP repositories outside of the project directory can be used too. this is how my project looks like: 

PROJECT_NAME
    ├── .git
    ├── .gitignore
    ├── project_name.tcl         # Project generator script
    ├── src/                     # Tracked source files
    │   ├── design/
    │   │    ├── *.v
    │   │    └── *.vhd
    │   ├── testbench/
    │   │    ├── *.v
    │   │    └── *.vhd
    │   └── ...
    ├── ips/                     # Tracked project-specific IP repository
    │   ├── my_first_ip/
    │   │    ├── src/
    │   │    ├── xgui/
    |     |     ├── vivado_project   # This is the example design project and it may need other IPs to work like "my_second_ip"
    |     |     ├── example_design.tcl
    │   │    └── component.xml
    │   ├── my_second_ip/
    │   └── ...
    └── vivado_project/          # Untracked generated files